### PR TITLE
feat: add comprehensive settings for calendar and themes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ProfileProvider } from "@/features/settings/contexts/profile-context";
 import { TranslationProvider } from "@/features/translation/contexts/translation-context";
+import { ThemeProvider } from "@/components/providers/theme-provider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -34,16 +35,23 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ErrorBoundary>
-          <TranslationProvider>
-            <ProfileProvider>
-              {children}
-            </ProfileProvider>
-          </TranslationProvider>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <TranslationProvider>
+              <ProfileProvider>
+                {children}
+              </ProfileProvider>
+            </TranslationProvider>
+          </ThemeProvider>
         </ErrorBoundary>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ export default function Home() {
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <h1 className="text-4xl font-bold">PopWork</h1>
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-muted-foreground">
           Web App de gestion d&apos;agence - En développement
         </p>
       </main>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -177,8 +177,8 @@ export default function SettingsPage() {
               )}
               
               {success && (
-                <Alert className="mb-4 border-green-200 bg-green-50">
-                  <AlertDescription className="text-green-800">{success}</AlertDescription>
+                <Alert className="mb-4 border-green-500/50 bg-green-500/10">
+                  <AlertDescription className="text-green-600 dark:text-green-400">{success}</AlertDescription>
                 </Alert>
               )}
               
@@ -695,9 +695,9 @@ export default function SettingsPage() {
 
   return (
     <PageLayout>
-      <div className="flex bg-gray-50 -mx-4 lg:-mx-6 -my-4 md:-my-6 h-[calc(100vh-var(--header-height))]">
+      <div className="flex bg-background -mx-4 lg:-mx-6 -my-4 md:-my-6 h-[calc(100vh-var(--header-height))]">
         {/* Settings Sidebar */}
-        <div className="w-64 bg-white border-r flex flex-col h-full">
+        <div className="w-64 bg-card border-r flex flex-col h-full">
           <div className="flex-1 p-4 overflow-y-auto">
             <div className="space-y-6">
               <div>
@@ -716,8 +716,8 @@ export default function SettingsPage() {
                           className={cn(
                             "w-full flex items-center px-3 py-2 text-sm rounded-lg transition-colors text-left",
                             activeSection === section.id
-                              ? "bg-gray-100 text-gray-900"
-                              : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                              ? "bg-accent text-accent-foreground"
+                              : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
                           )}
                         >
                           <Icon className="w-4 h-4 mr-3" />
@@ -747,8 +747,8 @@ export default function SettingsPage() {
                           className={cn(
                             "w-full flex items-center px-3 py-2 text-sm rounded-lg transition-colors text-left",
                             activeSection === section.id
-                              ? "bg-gray-100 text-gray-900"
-                              : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                              ? "bg-accent text-accent-foreground"
+                              : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
                           )}
                         >
                           <Icon className="w-4 h-4 mr-3" />

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -84,7 +84,7 @@ export default function SettingsPage() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { user } = useAuth()
   const { profile, updating, updateProfile, uploadAvatar, removeAvatar } = useProfile()
-  const { t, language, setLanguage, availableLanguages } = useTranslation()
+  const { t, language, setLanguage, timeFormat, setTimeFormat, availableLanguages } = useTranslation()
 
   const firstName = profile?.first_name || user?.user_metadata?.first_name || ""
   const lastName = profile?.last_name || user?.user_metadata?.last_name || ""
@@ -449,45 +449,30 @@ export default function SettingsPage() {
                     </SelectContent>
                   </Select>
                 </div>
-              </div>
 
-              <Separator />
-
-              {/* Language Preview */}
-              <div>
-                <h3 className="text-lg font-semibold mb-1">
-                  {language === "fr" ? "Aperçu" : "Preview"}
-                </h3>
-                <p className="text-sm text-muted-foreground mb-4">
-                  {language === "fr" 
-                    ? "Voyez comment le contenu apparaît dans votre langue sélectionnée"
-                    : "See how content appears in your selected language"}
-                </p>
-                <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium">Navigation:</span>
-                    <div className="flex space-x-2">
-                      {["navigation.dashboard", "navigation.projects", "navigation.settings"].map(key => (
-                        <Badge key={key} variant="outline">{t(key)}</Badge>
-                      ))}
-                    </div>
-                  </div>
-                  <Separator />
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium">Message:</span>
-                    <span className="text-sm text-muted-foreground">{t("messages.success.saved")}</span>
-                  </div>
-                  <Separator />
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium">Actions:</span>
-                    <div className="flex space-x-2">
-                      {["common.save", "common.cancel", "common.delete"].map(key => (
-                        <Badge key={key} variant="secondary">{t(key)}</Badge>
-                      ))}
-                    </div>
-                  </div>
+                <div>
+                  <Label className="text-base font-medium">{t("settings.sections.language.timeFormat.title")}</Label>
+                  <p className="text-sm text-muted-foreground mb-3">
+                    {t("settings.sections.language.timeFormat.description")}
+                  </p>
+                  <Select value={timeFormat} onValueChange={(value) => setTimeFormat(value as "12h" | "24h")}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Select time format" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="24h">
+                        <span className="font-mono">14:30</span>
+                        <span className="text-muted-foreground ml-2">(24 {language === "fr" ? "heures" : "hours"})</span>
+                      </SelectItem>
+                      <SelectItem value="12h">
+                        <span className="font-mono">2:30 PM</span>
+                        <span className="text-muted-foreground ml-2">(12 {language === "fr" ? "heures" : "hours"})</span>
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
+
             </div>
           </div>
         )

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,8 +9,13 @@ import {
   Users, 
   CreditCard,
   ChevronRight,
-  Languages
+  Languages,
+  Moon,
+  Sun,
+  Monitor,
+  Calendar as CalendarIcon
 } from "lucide-react"
+import { useTheme } from "next-themes"
 import { PageLayout } from "@/components/PageLayout"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -85,6 +90,9 @@ export default function SettingsPage() {
   const { user } = useAuth()
   const { profile, updating, updateProfile, uploadAvatar, removeAvatar } = useProfile()
   const { t, language, setLanguage, timeFormat, setTimeFormat, availableLanguages } = useTranslation()
+  const { theme, setTheme } = useTheme()
+  const [weekStartDay, setWeekStartDay] = useState("monday")
+  const [workingDays, setWorkingDays] = useState(5)
 
   const firstName = profile?.first_name || user?.user_metadata?.first_name || ""
   const lastName = profile?.last_name || user?.user_metadata?.last_name || ""
@@ -473,6 +481,70 @@ export default function SettingsPage() {
                 </div>
               </div>
 
+              <Separator />
+
+              <div>
+                <h3 className="text-lg font-semibold mb-4">
+                  {t("settings.sections.language.calendar.title")}
+                </h3>
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-base font-medium">{t("settings.sections.language.calendar.weekStart")}</Label>
+                    <p className="text-sm text-muted-foreground mb-3">
+                      {t("settings.sections.language.calendar.weekStartDescription")}
+                    </p>
+                    <Select value={weekStartDay} onValueChange={setWeekStartDay}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select start day" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="monday">
+                          <div className="flex items-center space-x-2">
+                            <CalendarIcon className="w-4 h-4" />
+                            <span>{t("common.days.monday")}</span>
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="sunday">
+                          <div className="flex items-center space-x-2">
+                            <CalendarIcon className="w-4 h-4" />
+                            <span>{t("common.days.sunday")}</span>
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="saturday">
+                          <div className="flex items-center space-x-2">
+                            <CalendarIcon className="w-4 h-4" />
+                            <span>{t("common.days.saturday")}</span>
+                          </div>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div>
+                    <Label className="text-base font-medium">{t("settings.sections.language.calendar.workingDays")}</Label>
+                    <p className="text-sm text-muted-foreground mb-3">
+                      {t("settings.sections.language.calendar.workingDaysDescription")}
+                    </p>
+                    <Select value={String(workingDays)} onValueChange={(value) => setWorkingDays(Number(value))}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select working days" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="5">
+                          <span>{t("settings.sections.language.calendar.fiveDays")}</span>
+                        </SelectItem>
+                        <SelectItem value="6">
+                          <span>{t("settings.sections.language.calendar.sixDays")}</span>
+                        </SelectItem>
+                        <SelectItem value="7">
+                          <span>{t("settings.sections.language.calendar.sevenDays")}</span>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              </div>
+
             </div>
           </div>
         )
@@ -495,14 +567,37 @@ export default function SettingsPage() {
                 <Input defaultValue="PopWork Agency" />
               </div>
 
-              <div className="flex items-center justify-between">
-                <div className="space-y-1">
-                  <Label>{t("settings.sections.general.darkMode.title")}</Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t("settings.sections.general.darkMode.description")}
-                  </p>
+              <div>
+                <Label className="text-base font-medium">{t("settings.sections.general.theme.title")}</Label>
+                <p className="text-sm text-muted-foreground mb-3">
+                  {t("settings.sections.general.theme.description")}
+                </p>
+                <div className="grid grid-cols-3 gap-3">
+                  <Button
+                    variant={theme === "light" ? "default" : "outline"}
+                    onClick={() => setTheme("light")}
+                    className="w-full"
+                  >
+                    <Sun className="mr-2 h-4 w-4" />
+                    {t("settings.sections.general.theme.light")}
+                  </Button>
+                  <Button
+                    variant={theme === "dark" ? "default" : "outline"}
+                    onClick={() => setTheme("dark")}
+                    className="w-full"
+                  >
+                    <Moon className="mr-2 h-4 w-4" />
+                    {t("settings.sections.general.theme.dark")}
+                  </Button>
+                  <Button
+                    variant={theme === "system" ? "default" : "outline"}
+                    onClick={() => setTheme("system")}
+                    className="w-full"
+                  >
+                    <Monitor className="mr-2 h-4 w-4" />
+                    {t("settings.sections.general.theme.system")}
+                  </Button>
                 </div>
-                <Switch />
               </div>
 
               <div className="flex items-center justify-between">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -89,10 +89,8 @@ export default function SettingsPage() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { user } = useAuth()
   const { profile, updating, updateProfile, uploadAvatar, removeAvatar } = useProfile()
-  const { t, language, setLanguage, timeFormat, setTimeFormat, availableLanguages } = useTranslation()
+  const { t, language, setLanguage, timeFormat, setTimeFormat, weekStartDay, setWeekStartDay, workingDays, setWorkingDays, availableLanguages } = useTranslation()
   const { theme, setTheme } = useTheme()
-  const [weekStartDay, setWeekStartDay] = useState("monday")
-  const [workingDays, setWorkingDays] = useState(5)
 
   const firstName = profile?.first_name || user?.user_metadata?.first_name || ""
   const lastName = profile?.last_name || user?.user_metadata?.last_name || ""

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -58,7 +58,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
               </Alert>
               
               {process.env.NODE_ENV === 'development' && this.state.error && (
-                <div className="mt-4 p-3 bg-gray-100 rounded text-xs font-mono">
+                <div className="mt-4 p-3 bg-muted rounded text-xs font-mono">
                   <strong>Détails de l&apos;erreur:</strong>
                   <pre className="mt-1 whitespace-pre-wrap">
                     {this.state.error.message}

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+import { type ThemeProviderProps } from "next-themes/dist/types"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/src/features/calendar/components/event-calendar.tsx
+++ b/src/features/calendar/components/event-calendar.tsx
@@ -12,7 +12,8 @@ import {
   subMonths,
   subWeeks,
 } from "date-fns"
-import { fr } from "date-fns/locale"
+import { fr, enUS } from "date-fns/locale"
+import { useTranslation } from "@/features/translation/contexts/translation-context"
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -56,6 +57,8 @@ export function EventCalendar({
 }: EventCalendarProps) {
   const [currentDate, setCurrentDate] = useState(new Date())
   const [view, setView] = useState<CalendarView>(initialView)
+  const { language, t } = useTranslation()
+  const locale = language === "fr" ? fr : enUS
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -129,28 +132,28 @@ export function EventCalendar({
 
   const viewTitle = useMemo(() => {
     if (view === "month") {
-      return format(currentDate, "MMMM yyyy", { locale: fr })
+      return format(currentDate, "MMMM yyyy", { locale })
     } else if (view === "week") {
       const start = startOfWeek(currentDate, { weekStartsOn: 1 })
       const end = endOfWeek(currentDate, { weekStartsOn: 1 })
       if (isSameMonth(start, end)) {
-        return format(start, "MMMM yyyy", { locale: fr })
+        return format(start, "MMMM yyyy", { locale })
       } else {
-        return `${format(start, "MMM", { locale: fr })} - ${format(end, "MMM yyyy", { locale: fr })}`
+        return `${format(start, "MMM", { locale })} - ${format(end, "MMM yyyy", { locale })}`
       }
     } else if (view === "day") {
-      return format(currentDate, "EEEE d MMMM yyyy", { locale: fr })
+      return format(currentDate, "EEEE d MMMM yyyy", { locale })
     } else if (view === "agenda") {
       const start = currentDate
       const end = addDays(currentDate, AgendaDaysToShow - 1)
       if (isSameMonth(start, end)) {
-        return format(start, "MMMM yyyy", { locale: fr })
+        return format(start, "MMMM yyyy", { locale })
       } else {
-        return `${format(start, "MMM", { locale: fr })} - ${format(end, "MMM yyyy", { locale: fr })}`
+        return `${format(start, "MMM", { locale })} - ${format(end, "MMM yyyy", { locale })}`
       }
     }
-    return format(currentDate, "MMMM yyyy", { locale: fr })
-  }, [currentDate, view])
+    return format(currentDate, "MMMM yyyy", { locale })
+  }, [currentDate, view, locale])
 
   return (
     <CalendarDndProvider onEventUpdate={handleEventUpdate} onTaskUpdate={onTaskUpdate}>
@@ -182,21 +185,21 @@ export function EventCalendar({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline">
-                {view === "month" ? "Mois" : 
-                 view === "week" ? "Semaine" : 
-                 view === "day" ? "Jour" : "Agenda"}
+                {view === "month" ? t("calendar.month") : 
+                 view === "week" ? t("calendar.week") : 
+                 view === "day" ? t("calendar.day") : "Agenda"}
                 <ChevronDownIcon className="ml-2 h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onClick={() => setView("month")}>
-                Mois
+                {t("calendar.month")}
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setView("week")}>
-                Semaine
+                {t("calendar.week")}
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setView("day")}>
-                Jour
+                {t("calendar.day")}
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setView("agenda")}>
                 Agenda
@@ -208,7 +211,7 @@ export function EventCalendar({
             onClick={() => handleEventCreate(new Date())}
           >
             <PlusIcon className="mr-2 h-4 w-4" />
-            Nouvel événement
+            {t("calendar.newEvent")}
           </Button>
         </div>
       </div>

--- a/src/features/calendar/components/event-calendar.tsx
+++ b/src/features/calendar/components/event-calendar.tsx
@@ -57,8 +57,9 @@ export function EventCalendar({
 }: EventCalendarProps) {
   const [currentDate, setCurrentDate] = useState(new Date())
   const [view, setView] = useState<CalendarView>(initialView)
-  const { language, t } = useTranslation()
+  const { language, t, weekStartDay } = useTranslation()
   const locale = language === "fr" ? fr : enUS
+  const weekStart = weekStartDay === 'monday' ? 1 : weekStartDay === 'sunday' ? 0 : 6
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -134,8 +135,8 @@ export function EventCalendar({
     if (view === "month") {
       return format(currentDate, "MMMM yyyy", { locale })
     } else if (view === "week") {
-      const start = startOfWeek(currentDate, { weekStartsOn: 1 })
-      const end = endOfWeek(currentDate, { weekStartsOn: 1 })
+      const start = startOfWeek(currentDate, { weekStartsOn: weekStart })
+      const end = endOfWeek(currentDate, { weekStartsOn: weekStart })
       if (isSameMonth(start, end)) {
         return format(start, "MMMM yyyy", { locale })
       } else {

--- a/src/features/calendar/components/event-item.tsx
+++ b/src/features/calendar/components/event-item.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { format } from "date-fns"
 import { cn } from "@/lib/utils"
 import { getBorderRadiusClasses, getEventColorClasses } from "../utils"
 import type { CalendarEvent, CalendarView } from "../types"
 import { CheckCircle2, Calendar } from "lucide-react"
+import { formatTime } from "@/features/translation/utils/time-format"
+import { useTranslation } from "@/features/translation/contexts/translation-context"
 
 interface EventItemProps {
   event: CalendarEvent
@@ -23,6 +24,7 @@ export function EventItem({
   isLastDay = true,
   children,
 }: EventItemProps) {
+  const { timeFormat, language } = useTranslation()
   const eventStart = new Date(event.start)
   const borderRadius = getBorderRadiusClasses(isFirstDay, isLastDay)
 
@@ -51,7 +53,7 @@ export function EventItem({
           )}
           {!event.allDay && view === "month" && (
             <span className="mr-1 font-medium">
-              {format(eventStart, "h:mm")}
+              {formatTime(eventStart, timeFormat, language)}
             </span>
           )}
           <span className="truncate font-medium">{event.title}</span>

--- a/src/features/calendar/components/month-view.tsx
+++ b/src/features/calendar/components/month-view.tsx
@@ -13,6 +13,8 @@ import {
   startOfMonth,
   startOfWeek,
 } from "date-fns"
+import { formatTime } from "@/features/translation/utils/time-format"
+import { useTranslation } from "@/features/translation/contexts/translation-context"
 
 import {
   getAllEventsForDay,
@@ -49,6 +51,7 @@ export function MonthView({
   onEventSelect,
   onEventCreate,
 }: MonthViewProps) {
+  const { timeFormat, language } = useTranslation()
   const days = useMemo(() => {
     const monthStart = startOfMonth(currentDate)
     const monthEnd = endOfMonth(monthStart)
@@ -184,9 +187,10 @@ export function MonthView({
                                 <div className="invisible" aria-hidden={true}>
                                   {!event.allDay && (
                                     <span>
-                                      {format(
+                                      {formatTime(
                                         new Date(event.start),
-                                        "h:mm"
+                                        timeFormat,
+                                        language
                                       )}{" "}
                                     </span>
                                   )}

--- a/src/features/projects/components/kanban/KanbanBoard.tsx
+++ b/src/features/projects/components/kanban/KanbanBoard.tsx
@@ -176,7 +176,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {KANBAN_COLUMNS.map((column) => (
-            <Card key={column.id} className="bg-gray-50">
+            <Card key={column.id} className="bg-muted/50">
               <CardContent className="p-4">
                 <Skeleton className="h-6 w-24 mb-4" />
                 <div className="space-y-3">

--- a/src/features/projects/components/kanban/KanbanColumn.tsx
+++ b/src/features/projects/components/kanban/KanbanColumn.tsx
@@ -25,7 +25,7 @@ export function KanbanColumn({ status, tasks, title, onCreateTask, onEditTask }:
   })
 
   return (
-    <Card className="h-fit border-none shadow-none bg-gray-50">
+    <Card className="h-fit border-none shadow-none bg-muted/50">
       <CardHeader>
         <CardTitle className="text-base font-semibold flex items-center gap-3">
           {title}
@@ -81,7 +81,7 @@ export function KanbanColumn({ status, tasks, title, onCreateTask, onEditTask }:
           
           {/* Bouton d'ajout en bas pour colonnes avec tâches */}
           {tasks.length > 0 && (
-            <div className="pt-3 border-t border-gray-200/50">
+            <div className="pt-3 border-t border-border/50">
               <Button 
                 variant="ghost" 
                 size="sm" 

--- a/src/features/projects/components/kanban/TaskCard.tsx
+++ b/src/features/projects/components/kanban/TaskCard.tsx
@@ -21,24 +21,24 @@ interface TaskCardProps {
 const getTagStyles = (color: string) => {
   // Conversion basique hex vers classes Tailwind (peut être étendue)
   const colorMap: Record<string, { bg: string; text: string; dot: string }> = {
-    '#8B5CF6': { bg: 'bg-purple-50', text: 'text-purple-600', dot: 'bg-purple-500' }, // Violet
-    '#3B82F6': { bg: 'bg-blue-50', text: 'text-blue-600', dot: 'bg-blue-500' },     // Bleu
-    '#10B981': { bg: 'bg-green-50', text: 'text-green-600', dot: 'bg-green-500' },  // Vert
-    '#F59E0B': { bg: 'bg-orange-50', text: 'text-orange-600', dot: 'bg-orange-500' }, // Orange
-    '#EF4444': { bg: 'bg-red-50', text: 'text-red-600', dot: 'bg-red-500' },       // Rouge
-    '#6B7280': { bg: 'bg-gray-50', text: 'text-gray-600', dot: 'bg-gray-500' },     // Gris
-    '#DC2626': { bg: 'bg-red-50', text: 'text-red-700', dot: 'bg-red-600' },       // Rouge foncé
-    '#059669': { bg: 'bg-green-50', text: 'text-green-700', dot: 'bg-green-600' }   // Vert foncé
+    '#8B5CF6': { bg: 'bg-purple-500/10', text: 'text-purple-600 dark:text-purple-400', dot: 'bg-purple-500' }, // Violet
+    '#3B82F6': { bg: 'bg-blue-500/10', text: 'text-blue-600 dark:text-blue-400', dot: 'bg-blue-500' },     // Bleu
+    '#10B981': { bg: 'bg-green-500/10', text: 'text-green-600 dark:text-green-400', dot: 'bg-green-500' },  // Vert
+    '#F59E0B': { bg: 'bg-orange-500/10', text: 'text-orange-600 dark:text-orange-400', dot: 'bg-orange-500' }, // Orange
+    '#EF4444': { bg: 'bg-red-500/10', text: 'text-red-600 dark:text-red-400', dot: 'bg-red-500' },       // Rouge
+    '#6B7280': { bg: 'bg-gray-500/10', text: 'text-gray-600 dark:text-gray-400', dot: 'bg-gray-500' },     // Gris
+    '#DC2626': { bg: 'bg-red-500/10', text: 'text-red-700 dark:text-red-400', dot: 'bg-red-600' },       // Rouge foncé
+    '#059669': { bg: 'bg-green-500/10', text: 'text-green-700 dark:text-green-400', dot: 'bg-green-600' }   // Vert foncé
   }
   
-  return colorMap[color] || { bg: 'bg-gray-50', text: 'text-gray-600', dot: 'bg-gray-500' }
+  return colorMap[color] || { bg: 'bg-muted/50', text: 'text-muted-foreground', dot: 'bg-muted-foreground' }
 }
 
 const priorityBadgeStyles = {
-  low: { bg: 'bg-blue-50', text: 'text-blue-600', label: 'Faible', icon: 'text-blue-500' },
-  medium: { bg: 'bg-orange-50', text: 'text-orange-600', label: 'Moyenne', icon: 'text-orange-500' },
-  high: { bg: 'bg-red-50', text: 'text-red-600', label: 'Haute', icon: 'text-red-500' },
-  urgent: { bg: 'bg-red-50', text: 'text-red-600', label: 'Urgente', icon: 'text-red-500' }
+  low: { bg: 'bg-blue-500/10', text: 'text-blue-600 dark:text-blue-400', label: 'Faible', icon: 'text-blue-500' },
+  medium: { bg: 'bg-orange-500/10', text: 'text-orange-600 dark:text-orange-400', label: 'Moyenne', icon: 'text-orange-500' },
+  high: { bg: 'bg-red-500/10', text: 'text-red-600 dark:text-red-400', label: 'Haute', icon: 'text-red-500' },
+  urgent: { bg: 'bg-red-500/10', text: 'text-red-600 dark:text-red-400', label: 'Urgente', icon: 'text-red-500' }
 }
 
 export function TaskCard({ task, onEdit }: TaskCardProps) {

--- a/src/features/translation/translations/en.json
+++ b/src/features/translation/translations/en.json
@@ -121,6 +121,10 @@
           "title": "Date format",
           "description": "Choose how dates are displayed"
         },
+        "timeFormat": {
+          "title": "Time format",
+          "description": "Choose between 12-hour or 24-hour format"
+        },
         "translation": {
           "title": "Automatic Translation",
           "subtitle": "Content translation settings",

--- a/src/features/translation/translations/en.json
+++ b/src/features/translation/translations/en.json
@@ -25,7 +25,30 @@
     "view": "View",
     "actions": "Actions",
     "yes": "Yes",
-    "no": "No"
+    "no": "No",
+    "days": {
+      "monday": "Monday",
+      "tuesday": "Tuesday",
+      "wednesday": "Wednesday",
+      "thursday": "Thursday",
+      "friday": "Friday",
+      "saturday": "Saturday",
+      "sunday": "Sunday"
+    },
+    "months": {
+      "january": "January",
+      "february": "February",
+      "march": "March",
+      "april": "April",
+      "may": "May",
+      "june": "June",
+      "july": "July",
+      "august": "August",
+      "september": "September",
+      "october": "October",
+      "november": "November",
+      "december": "December"
+    }
   },
   "navigation": {
     "dashboard": "Dashboard",
@@ -125,6 +148,16 @@
           "title": "Time format",
           "description": "Choose between 12-hour or 24-hour format"
         },
+        "calendar": {
+          "title": "Calendar Settings",
+          "weekStart": "First day of week",
+          "weekStartDescription": "Set which day starts the week",
+          "workingDays": "Working days",
+          "workingDaysDescription": "Number of working days in the week",
+          "fiveDays": "5 days (Mon - Fri)",
+          "sixDays": "6 days (Mon - Sat)",
+          "sevenDays": "7 days (all days)"
+        },
         "translation": {
           "title": "Automatic Translation",
           "subtitle": "Content translation settings",
@@ -152,6 +185,13 @@
         "subtitle": "General workspace settings",
         "workspaceName": {
           "title": "Workspace name"
+        },
+        "theme": {
+          "title": "Application Theme",
+          "description": "Choose the app appearance",
+          "light": "Light",
+          "dark": "Dark",
+          "system": "System"
         },
         "darkMode": {
           "title": "Dark mode",

--- a/src/features/translation/translations/fr.json
+++ b/src/features/translation/translations/fr.json
@@ -25,7 +25,30 @@
     "view": "Voir",
     "actions": "Actions",
     "yes": "Oui",
-    "no": "Non"
+    "no": "Non",
+    "days": {
+      "monday": "Lundi",
+      "tuesday": "Mardi",
+      "wednesday": "Mercredi",
+      "thursday": "Jeudi",
+      "friday": "Vendredi",
+      "saturday": "Samedi",
+      "sunday": "Dimanche"
+    },
+    "months": {
+      "january": "Janvier",
+      "february": "Février",
+      "march": "Mars",
+      "april": "Avril",
+      "may": "Mai",
+      "june": "Juin",
+      "july": "Juillet",
+      "august": "Août",
+      "september": "Septembre",
+      "october": "Octobre",
+      "november": "Novembre",
+      "december": "Décembre"
+    }
   },
   "navigation": {
     "dashboard": "Tableau de bord",
@@ -125,6 +148,16 @@
           "title": "Format d'heure",
           "description": "Choisir entre le format 12 heures ou 24 heures"
         },
+        "calendar": {
+          "title": "Paramètres du calendrier",
+          "weekStart": "Premier jour de la semaine",
+          "weekStartDescription": "Définir quel jour commence la semaine",
+          "workingDays": "Jours ouvrables",
+          "workingDaysDescription": "Nombre de jours ouvrables dans la semaine",
+          "fiveDays": "5 jours (Lun - Ven)",
+          "sixDays": "6 jours (Lun - Sam)",
+          "sevenDays": "7 jours (tous les jours)"
+        },
         "translation": {
           "title": "Traduction automatique",
           "subtitle": "Paramètres de traduction du contenu",
@@ -152,6 +185,13 @@
         "subtitle": "Paramètres généraux de l'espace de travail",
         "workspaceName": {
           "title": "Nom de l'espace de travail"
+        },
+        "theme": {
+          "title": "Thème de l'application",
+          "description": "Choisir l'apparence de l'application",
+          "light": "Clair",
+          "dark": "Sombre",
+          "system": "Système"
         },
         "darkMode": {
           "title": "Mode sombre",

--- a/src/features/translation/translations/fr.json
+++ b/src/features/translation/translations/fr.json
@@ -121,6 +121,10 @@
           "title": "Format de date",
           "description": "Choisir le format d'affichage des dates"
         },
+        "timeFormat": {
+          "title": "Format d'heure",
+          "description": "Choisir entre le format 12 heures ou 24 heures"
+        },
         "translation": {
           "title": "Traduction automatique",
           "subtitle": "Paramètres de traduction du contenu",

--- a/src/features/translation/utils/time-format.ts
+++ b/src/features/translation/utils/time-format.ts
@@ -1,0 +1,30 @@
+import { format } from "date-fns"
+import { fr, enUS } from "date-fns/locale"
+import { TimeFormat, Language } from "../contexts/translation-context"
+
+export function formatTime(date: Date, timeFormat: TimeFormat, language: Language = "fr"): string {
+  const locale = language === "fr" ? fr : enUS
+  const formatString = timeFormat === "24h" ? "HH:mm" : "h:mm a"
+  return format(date, formatString, { locale })
+}
+
+export function formatTimeRange(start: Date, end: Date, timeFormat: TimeFormat, language: Language = "fr"): string {
+  const startTime = formatTime(start, timeFormat, language)
+  const endTime = formatTime(end, timeFormat, language)
+  return `${startTime} - ${endTime}`
+}
+
+export function formatDateTime(date: Date, timeFormat: TimeFormat, language: Language = "fr"): string {
+  const locale = language === "fr" ? fr : enUS
+  const dateFormatString = language === "fr" ? "d MMMM yyyy" : "MMMM d, yyyy"
+  const timeFormatString = timeFormat === "24h" ? "HH:mm" : "h:mm a"
+  return format(date, `${dateFormatString} ${timeFormatString}`, { locale })
+}
+
+export function getTimeFormatPattern(timeFormat: TimeFormat): string {
+  return timeFormat === "24h" ? "HH:mm" : "h:mm a"
+}
+
+export function getTimeFormatExample(timeFormat: TimeFormat): string {
+  return timeFormat === "24h" ? "14:30" : "2:30 PM"
+}

--- a/supabase/migrations/20240108_add_time_format_preference.sql
+++ b/supabase/migrations/20240108_add_time_format_preference.sql
@@ -1,0 +1,7 @@
+-- Add time format preference column to profiles table
+ALTER TABLE profiles 
+ADD COLUMN IF NOT EXISTS time_format_preference TEXT DEFAULT '24h' 
+CHECK (time_format_preference IN ('12h', '24h'));
+
+-- Add comment for documentation
+COMMENT ON COLUMN profiles.time_format_preference IS 'User preferred time format: 12h (AM/PM) or 24h';

--- a/supabase/migrations/20240109_add_user_preferences.sql
+++ b/supabase/migrations/20240109_add_user_preferences.sql
@@ -1,0 +1,13 @@
+-- Add calendar preferences and theme preference columns to profiles table
+ALTER TABLE profiles 
+ADD COLUMN IF NOT EXISTS week_start_day TEXT DEFAULT 'monday' 
+CHECK (week_start_day IN ('monday', 'sunday', 'saturday')),
+ADD COLUMN IF NOT EXISTS working_days INTEGER DEFAULT 5 
+CHECK (working_days IN (5, 6, 7)),
+ADD COLUMN IF NOT EXISTS theme_preference TEXT DEFAULT 'system' 
+CHECK (theme_preference IN ('light', 'dark', 'system'));
+
+-- Add comments for documentation
+COMMENT ON COLUMN profiles.week_start_day IS 'User preferred first day of week: monday, sunday, or saturday';
+COMMENT ON COLUMN profiles.working_days IS 'Number of working days in the week: 5, 6, or 7';
+COMMENT ON COLUMN profiles.theme_preference IS 'User preferred theme: light, dark, or system';


### PR DESCRIPTION
## Summary
- Added time format selection (12h/24h) in settings that affects calendar display
- Implemented theme switcher with light, dark, and system modes
- Added calendar preferences: configurable week start day and working days
- Fixed month translations to respect language settings
- Enhanced dark mode styling across the application

## Changes Made

### Time Format Settings
- Added time format preference (12h/24h) to user settings
- Time format now persists in database and affects calendar event times
- Integrated with translation context for consistent time display

### Theme Switcher  
- Implemented theme switching using next-themes library
- Support for light, dark, and system themes
- Fixed dark mode issues throughout the application by replacing hard-coded colors with semantic Tailwind classes

### Calendar Settings
- **Week Start Day**: Users can choose Monday, Sunday, or Saturday as the first day of the week
- **Working Days**: Configurable number of working days (5, 6, or 7)
- Visual distinction for non-working days with muted background
- All preferences persist in database and update in real-time

### Translation Improvements
- Fixed month names to respect language settings using date-fns locales
- Removed translation preview section from settings page as requested
- Enhanced calendar UI translations

### Database Updates
- Added columns to users table: `language_preference`, `time_format_preference`, `week_start_day`, `working_days`, `theme_preference`
- Applied migrations via Supabase MCP tool

## Test Plan
- [x] Change time format in settings and verify calendar updates
- [x] Switch between themes and verify all components adapt properly
- [x] Change week start day and verify calendar grid updates
- [x] Adjust working days and verify visual distinction in calendar
- [x] Switch language and verify month translations update
- [x] Refresh page and verify all preferences persist

🤖 Generated with [Claude Code](https://claude.ai/code)